### PR TITLE
fix: correct maxExecutions handling in CronJob and update example

### DIFF
--- a/go/scheduled/example/create-cronjob/main.go
+++ b/go/scheduled/example/create-cronjob/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,9 +49,10 @@ func main() {
 		Spec: v1alpha1.CronJobSpec{
 			Schedule: &v1alpha1.ScheduleRule{
 				ConcurrencyPolicy: v1alpha1.ForbidConcurrent,
+				MaxExecutions:     ptr.To(int32(1)),
 				Schedule: []v1alpha1.ScheduleType{{
 					Interval: &v1alpha1.Interval{
-						Seconds: 30,
+						Seconds: 10,
 					},
 				}},
 			},
@@ -64,7 +66,7 @@ func main() {
 							Command: []string{
 								"/bin/bash",
 								"-c",
-								"echo \"starting ...\" && sleep 10 && echo \"done\"",
+								"echo \"starting ...\" && sleep 60 && echo \"done\"",
 							},
 						}},
 					},

--- a/scheduled/src/crd/cron.rs
+++ b/scheduled/src/crd/cron.rs
@@ -193,6 +193,9 @@ impl CronJob {
 
         if let Some(schedule) = self.spec.schedule.as_ref() {
             if let Some(max_executions) = schedule.max_executions {
+                if execution_count == max_executions && self.active_jobs_count() > 0 {
+                    return Some(now + Duration::seconds(5 * 50));
+                }
                 if execution_count >= max_executions {
                     return None;
                 }


### PR DESCRIPTION
- rust: Enhance CronJob logic to handle max_executions; if active jobs remain when limit is reached, delay next schedule
- go: Update example to use max_executions